### PR TITLE
Make the module more generic wrt annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ module "fluxcd" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_controller_ssh_private_key"></a> [controller\_ssh\_private\_key](#input\_controller\_ssh\_private\_key) | SSH private key for flux controller | `string` | n/a | yes |
 | <a name="input_controller_ssh_public_key"></a> [controller\_ssh\_public\_key](#input\_controller\_ssh\_public\_key) | SSH public key for flux controller | `string` | n/a | yes |
-| <a name="input_service_account_annotations"></a> [service\_account\_annotations](#input\_service\_account\_annotations) | Annotations·to·add·to·the·kustomize-controller service account in flux-system namespace | `string` | n/a | no |
-| <a name="input_service_account_labels"></a> [service\_account\_labels](#input\_service\_account\_labels) | Labels·to·add·to·the·kustomize-controller service account in flux-system namespace | `string` | n/a | no |
 | <a name="input_path"></a> [path](#input\_path) | Path relative to flux repository root where to look for manifests | `string` | n/a | yes |
 | <a name="input_annotations"></a> [annotations](#input\_annotations) | Annotations to add to created kubernetes resources | `map(string)` | `{}` | no |
 | <a name="input_cluster_variables"></a> [cluster\_variables](#input\_cluster\_variables) | Key-value pairs to create 'terraform-flux-cluster-variables' ConfigMap for flux/Kustomization postBuild use | `map(string)` | `{}` | no |
 | <a name="input_controller_ssh_known_hosts"></a> [controller\_ssh\_known\_hosts](#input\_controller\_ssh\_known\_hosts) | SSH known hosts for flux controller. Defaults to github.com ECDSA key. | `string` | `"github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="` | no |
 | <a name="input_fluxcd_version"></a> [fluxcd\_version](#input\_fluxcd\_version) | Flux version to use | `string` | `"v2.1.1"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy fluxcd to | `string` | `"flux-system"` | no |
+| <a name="input_service_account_annotations"></a> [service\_account\_annotations](#input\_service\_account\_annotations) | Annotations to add to the kustomize-controller service account | `map(string)` | `{}` | no |
+| <a name="input_service_account_labels"></a> [service\_account\_labels](#input\_service\_account\_labels) | Annotations to add to the kustomize-controller service account | `map(string)` | `{}` | no |
 | <a name="input_watch_all_namespaces"></a> [watch\_all\_namespaces](#input\_watch\_all\_namespaces) | Whether flux controller should watch all namespaces for custom resources or not | `bool` | `true` | no |
 
 * * *

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ a read-only access to the repository.
 
 ```hcl
 module "fluxcd" {
-  source                     = "github.com/lassizci/terraform-eks-fluxcd-sops?ref=v0.14"
+  source                     = "github.com/neondatabase/terraform-eks-fluxcd-sops?ref=v0.16"
   path                       = "./clusters/dev"
   controller_ssh_public_key  = file("./deploy-key.pub")
   controller_ssh_private_key = file("./deploy-key.priv")
   controller_ssh_known_hosts = "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
-  irsa_role_arn              = "arn:aws:iam::123456789012:role/fluxcd-irsa-role"
+  service_account_annotations = {
+    "eks.amazonaws.com/role-arn" = "arn:aws:iam::123456789012:role/fluxcd-irsa-role"
+  }
 }
 ```
 
@@ -24,7 +26,8 @@ module "fluxcd" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_controller_ssh_private_key"></a> [controller\_ssh\_private\_key](#input\_controller\_ssh\_private\_key) | SSH private key for flux controller | `string` | n/a | yes |
 | <a name="input_controller_ssh_public_key"></a> [controller\_ssh\_public\_key](#input\_controller\_ssh\_public\_key) | SSH public key for flux controller | `string` | n/a | yes |
-| <a name="input_irsa_role_arn"></a> [irsa\_role\_arn](#input\_irsa\_role\_arn) | Arn of IRSA role that is mapped to kustomize-controller service account in flux-system namespace | `string` | n/a | yes |
+| <a name="input_service_account_annotations"></a> [service\_account\_annotations](#input\_service\_account\_annotations) | Annotations·to·add·to·the·kustomize-controller service account in flux-system namespace | `string` | n/a | no |
+| <a name="input_service_account_labels"></a> [service\_account\_labels](#input\_service\_account\_labels) | Labels·to·add·to·the·kustomize-controller service account in flux-system namespace | `string` | n/a | no |
 | <a name="input_path"></a> [path](#input\_path) | Path relative to flux repository root where to look for manifests | `string` | n/a | yes |
 | <a name="input_annotations"></a> [annotations](#input\_annotations) | Annotations to add to created kubernetes resources | `map(string)` | `{}` | no |
 | <a name="input_cluster_variables"></a> [cluster\_variables](#input\_cluster\_variables) | Key-value pairs to create 'terraform-flux-cluster-variables' ConfigMap for flux/Kustomization postBuild use | `map(string)` | `{}` | no |

--- a/kustomization.yaml.tpl
+++ b/kustomization.yaml.tpl
@@ -9,8 +9,8 @@ patches:
     kind: ServiceAccount
     metadata:
       name: kustomize-controller
-      annotations:
-        eks.amazonaws.com/role-arn: ${irsa_role_arn}
+      annotations: ${service_account_annotations}
+      labels: ${service_account_labels}
   target:
     kind: ServiceAccount
     name: kustomize-controller

--- a/main.tf
+++ b/main.tf
@@ -50,9 +50,12 @@ resource "flux_bootstrap_git" "this" {
   disable_secret_creation = true
   path                    = var.path
   watch_all_namespaces    = var.watch_all_namespaces
-  kustomization_override  = templatefile("${path.module}/kustomization.yaml.tpl", { irsa_role_arn = var.irsa_role_arn })
-  version                 = var.fluxcd_version
-  depends_on              = [kubernetes_secret.flux_system_secret]
+  kustomization_override = templatefile("${path.module}/kustomization.yaml.tpl", {
+    service_account_annotations = var.service_account_annotations
+    service_account_labels      = var.service_account_labels
+  })
+  version    = var.fluxcd_version
+  depends_on = [kubernetes_secret.flux_system_secret]
 
   lifecycle {
     ignore_changes = all

--- a/variables.tf
+++ b/variables.tf
@@ -15,12 +15,22 @@ variable "controller_ssh_private_key" {
   sensitive   = true
 }
 
-variable "irsa_role_arn" {
-  description = "Arn of IRSA role that is mapped to kustomize-controller service account in flux-system namespace"
-  type        = string
+# optional
+# For features such as workload/pod identity, adding specific
+# labels/annotations to service accounts is necessary, but those differ across
+# cloud providers.
+variable "service_account_annotations" {
+  description = "Annotations to add to the kustomize-controller service account"
+  type        = map(string)
+  default     = {}
 }
 
-# optional
+variable "service_account_labels" {
+  description = "Annotations to add to the kustomize-controller service account"
+  type        = map(string)
+  default     = {}
+}
+
 variable "controller_ssh_known_hosts" {
   description = "SSH known hosts for flux controller. Defaults to github.com ECDSA key."
   type        = string


### PR DESCRIPTION
This should make it possible to run Flux on other cloud providers where the mechanism to give an identity to pods might be different and rely on labels as well as annotations.

I marked this as v0.16 in the README now, but maybe it should be 1.0, considering that this would be a breaking change? idk if this follows semver.