### PR TITLE
Fix the handling of service account metadata variables

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.4.6
+          terraform_version: 1.6.6
 
       - name: Check terraform formatting
         run: terraform fmt -diff -check -recursive
@@ -45,3 +45,21 @@ jobs:
         output-file: README.md
         output-method: inject
         git-push: "true"
+
+  terraform-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.6.6
+
+      - name: Initialize Terraform
+        run: terraform init
+
+      - name: Run tests
+        run: terraform test
+

--- a/main.tf
+++ b/main.tf
@@ -51,8 +51,8 @@ resource "flux_bootstrap_git" "this" {
   path                    = var.path
   watch_all_namespaces    = var.watch_all_namespaces
   kustomization_override = templatefile("${path.module}/kustomization.yaml.tpl", {
-    service_account_annotations = var.service_account_annotations
-    service_account_labels      = var.service_account_labels
+    service_account_annotations = yamlencode(var.service_account_annotations)
+    service_account_labels      = yamlencode(var.service_account_labels)
   })
   version    = var.fluxcd_version
   depends_on = [kubernetes_secret.flux_system_secret]

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -1,0 +1,26 @@
+provider "flux" {
+  kubernetes = {
+    config_path = "/some/kube/config"
+  }
+  git = {
+    url = "https://does.not.exist"
+  }
+}
+
+
+variables {
+  path                       = "./clusters/dev"
+  controller_ssh_public_key  = "SOME_VERY_PUBLIC_KEY"
+  controller_ssh_private_key = "AN_EXTREMELY_SECRET_PRIVATE_KEY"
+  controller_ssh_known_hosts = "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
+  service_account_annotations = {
+    "eks.amazonaws.com/role-arn" = "arn:aws:iam::123456789012:role/fluxcd-irsa-role"
+  }
+  service_account_labels = {
+    "foo" = "bar"
+  }
+}
+
+run "validate" {
+  command = plan
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.6"
 
   required_providers {
     kubernetes = {


### PR DESCRIPTION
`templatefile` can only take strings it seems? Also add some basic testing to
validate changes.

In #6, I made some changes that when used according to the docs in the
README just couldn't work. I would have hoped that Terraform had a better 
typing/testing story, but this is the best I could come up with to prevent 
that at present.