### PR TITLE
Add the ability to inject labels on the kustomization controller pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ module "fluxcd" {
 | <a name="input_controller_ssh_private_key"></a> [controller\_ssh\_private\_key](#input\_controller\_ssh\_private\_key) | SSH private key for flux controller | `string` | n/a | yes |
 | <a name="input_controller_ssh_public_key"></a> [controller\_ssh\_public\_key](#input\_controller\_ssh\_public\_key) | SSH public key for flux controller | `string` | n/a | yes |
 | <a name="input_path"></a> [path](#input\_path) | Path relative to flux repository root where to look for manifests | `string` | n/a | yes |
-| <a name="input_annotations"></a> [annotations](#input\_annotations) | Annotations to add to created kubernetes resources | `map(string)` | `{}` | no |
 | <a name="input_cluster_variables"></a> [cluster\_variables](#input\_cluster\_variables) | Key-value pairs to create 'terraform-flux-cluster-variables' ConfigMap for flux/Kustomization postBuild use | `map(string)` | `{}` | no |
 | <a name="input_controller_ssh_known_hosts"></a> [controller\_ssh\_known\_hosts](#input\_controller\_ssh\_known\_hosts) | SSH known hosts for flux controller. Defaults to github.com ECDSA key. | `string` | `"github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="` | no |
 | <a name="input_fluxcd_version"></a> [fluxcd\_version](#input\_fluxcd\_version) | Flux version to use | `string` | `"v2.1.1"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy fluxcd to | `string` | `"flux-system"` | no |
+| <a name="input_pod_labels"></a> [pod\_labels](#input\_pod\_labels) | Labels to add to the kustomize-controller pods | `map(string)` | `{}` | no |
 | <a name="input_service_account_annotations"></a> [service\_account\_annotations](#input\_service\_account\_annotations) | Annotations to add to the kustomize-controller service account | `map(string)` | `{}` | no |
 | <a name="input_service_account_labels"></a> [service\_account\_labels](#input\_service\_account\_labels) | Annotations to add to the kustomize-controller service account | `map(string)` | `{}` | no |
 | <a name="input_watch_all_namespaces"></a> [watch\_all\_namespaces](#input\_watch\_all\_namespaces) | Whether flux controller should watch all namespaces for custom resources or not | `bool` | `true` | no |

--- a/kustomization.yaml.tpl
+++ b/kustomization.yaml.tpl
@@ -16,6 +16,18 @@ patches:
     name: kustomize-controller
     labelSelector: app.kubernetes.io/part-of=flux
 - patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: kustomize-controller
+    spec:
+      template:
+        metadata:
+          labels: ${pod_labels}
+  target:
+    kind: Deployment
+    name: kustomize-controller
+- patch: |
     apiVersion: kustomize.toolkit.fluxcd.io/v1
     kind: Kustomization
     metadata:

--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,7 @@
 ################################################################################
 resource "kubernetes_namespace" "flux_system_ns" {
   metadata {
-    name        = var.namespace
-    annotations = var.annotations
+    name = var.namespace
   }
 
   lifecycle {
@@ -14,9 +13,8 @@ resource "kubernetes_namespace" "flux_system_ns" {
 
 resource "kubernetes_secret" "flux_system_secret" {
   metadata {
-    name        = "flux-system"
-    namespace   = var.namespace
-    annotations = var.annotations
+    name      = "flux-system"
+    namespace = var.namespace
   }
 
   data = {
@@ -32,9 +30,8 @@ resource "kubernetes_config_map" "flux_cluster_variables" {
   count = length(var.cluster_variables) > 0 ? 1 : 0
 
   metadata {
-    name        = "terraform-flux-cluster-variables"
-    namespace   = var.namespace
-    annotations = var.annotations
+    name      = "terraform-flux-cluster-variables"
+    namespace = var.namespace
   }
   data = var.cluster_variables
 
@@ -53,6 +50,7 @@ resource "flux_bootstrap_git" "this" {
   kustomization_override = templatefile("${path.module}/kustomization.yaml.tpl", {
     service_account_annotations = yamlencode(var.service_account_annotations)
     service_account_labels      = yamlencode(var.service_account_labels)
+    pod_labels                  = yamlencode(var.pod_labels)
   })
   version    = var.fluxcd_version
   depends_on = [kubernetes_secret.flux_system_secret]

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -19,6 +19,9 @@ variables {
   service_account_labels = {
     "foo" = "bar"
   }
+  pod_labels = {
+    "some.cloud.provider/identity" = "true"
+  }
 }
 
 run "validate" {

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "service_account_labels" {
   default     = {}
 }
 
+variable "pod_labels" {
+  description = "Labels to add to the kustomize-controller pods"
+  type        = map(string)
+  default     = {}
+}
+
 variable "controller_ssh_known_hosts" {
   description = "SSH known hosts for flux controller. Defaults to github.com ECDSA key."
   type        = string
@@ -41,12 +47,6 @@ variable "namespace" {
   description = "Kubernetes namespace to deploy fluxcd to"
   type        = string
   default     = "flux-system"
-}
-
-variable "annotations" {
-  description = "Annotations to add to created kubernetes resources"
-  type        = map(string)
-  default     = {}
 }
 
 variable "cluster_variables" {


### PR DESCRIPTION
Also remove an unused variable. This should make it possible to use Azure Workload Identity for Flux.