### PR TITLE
Encode labels and annotations in json for Kustomization

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,9 +48,9 @@ resource "flux_bootstrap_git" "this" {
   path                    = var.path
   watch_all_namespaces    = var.watch_all_namespaces
   kustomization_override = templatefile("${path.module}/kustomization.yaml.tpl", {
-    service_account_annotations = yamlencode(var.service_account_annotations)
-    service_account_labels      = yamlencode(var.service_account_labels)
-    pod_labels                  = yamlencode(var.pod_labels)
+    service_account_annotations = jsonencode(var.service_account_annotations)
+    service_account_labels      = jsonencode(var.service_account_labels)
+    pod_labels                  = jsonencode(var.pod_labels)
   })
   version    = var.fluxcd_version
   depends_on = [kubernetes_secret.flux_system_secret]


### PR DESCRIPTION
Encoding them with yaml will mean that the annotations variable will end
up being something like this:

```yaml
foo: bar
bar: baz
```

When injected into the Kustomization however, that's not sufficient,
because it will result in the following:

```yaml
patches:
- patch: |
    apiVersion: v1
    kind: ServiceAccount
    metadata:
      name: kustomize-controller
      annotations: "bar": "baz"
"foo": "bar"
```

Which is of course not valid. JSON encoding solves that because YAML is
a superset of JSON, so any JSON is valid YAML, and it doesn't rely on
indentation but can just be used inline, resulting in the following:

```yaml
patches:
- patch: |
    apiVersion: v1
    kind: ServiceAccount
    metadata:
      name: kustomize-controller
      annotations: {"bar": "baz", "foo": "bar"}
```

Which is actually valid.