### PR TITLE
Remove the lifecycle rule, manage fluxcd with terraform exclusively

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,8 +64,4 @@ resource "flux_bootstrap_git" "this" {
   })
   version    = var.fluxcd_version
   depends_on = [kubernetes_secret.flux_system_secret]
-
-  lifecycle {
-    ignore_changes = all
-  }
 }


### PR DESCRIPTION
Seems the ignoring lifecycle rules do not work. The original thought was, `flux_bootstrap_git` would have been used to _only_ FluxCD bootstrapping, as also the name might suggest. But it turns out if we ignore changes and change something in the `kustomization_override` on terraform side, the state doesn't get updated even with `-refresh-only` and as a result we'd be re-applying the initial values - for example IRSA role arn or Azure workload identity etc.

So lets remove the lifecycle rule completely and accept we have to manage flux with terraform, as recommended in  https://github.com/fluxcd/terraform-provider-flux/issues/477 - as `flux_bootstrap_git` is used.