### PR TITLE
FluxCD to version 2.3.0, provider to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module "fluxcd" {
 | <a name="input_cluster_secrets"></a> [cluster\_secrets](#input\_cluster\_secrets) | Key-value pairs to create 'terraform-flux-cluster-secrets' Secret for flux/Kustomization postBuild use | `map(string)` | `{}` | no |
 | <a name="input_cluster_variables"></a> [cluster\_variables](#input\_cluster\_variables) | Key-value pairs to create 'terraform-flux-cluster-variables' ConfigMap for flux/Kustomization postBuild use | `map(string)` | `{}` | no |
 | <a name="input_controller_ssh_known_hosts"></a> [controller\_ssh\_known\_hosts](#input\_controller\_ssh\_known\_hosts) | SSH known hosts for flux controller. Defaults to github.com ECDSA key. | `string` | `"github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="` | no |
-| <a name="input_fluxcd_version"></a> [fluxcd\_version](#input\_fluxcd\_version) | Flux version to use | `string` | `"v2.1.1"` | no |
+| <a name="input_fluxcd_version"></a> [fluxcd\_version](#input\_fluxcd\_version) | Flux version to use | `string` | `"v2.3.0"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy fluxcd to | `string` | `"flux-system"` | no |
 | <a name="input_pod_labels"></a> [pod\_labels](#input\_pod\_labels) | Labels to add to the kustomize-controller pods | `map(string)` | `{}` | no |
 | <a name="input_service_account_annotations"></a> [service\_account\_annotations](#input\_service\_account\_annotations) | Annotations to add to the kustomize-controller service account | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -71,5 +71,5 @@ variable "watch_all_namespaces" {
 variable "fluxcd_version" {
   description = "Flux version to use"
   type        = string
-  default     = "v2.1.1"
+  default     = "v2.3.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     flux = {
       source  = "fluxcd/flux"
-      version = ">= 1.1.1"
+      version = ">= 1.3.0"
     }
   }
 }


### PR DESCRIPTION
The module now requires flux provider version 1.3.0 and FluxCD version is set to 2.3.0 by default.