### PR TITLE
Add new variables introduced by flux provider 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ module "fluxcd" {
 | [kubernetes_namespace.flux_system_ns](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_secret.flux_cluster_secrets](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.flux_system_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [terraform_data.fluxcd_reprovision](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 
 </details>
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ module "fluxcd" {
 | <a name="input_cluster_secrets"></a> [cluster\_secrets](#input\_cluster\_secrets) | Key-value pairs to create 'terraform-flux-cluster-secrets' Secret for flux/Kustomization postBuild use | `map(string)` | `{}` | no |
 | <a name="input_cluster_variables"></a> [cluster\_variables](#input\_cluster\_variables) | Key-value pairs to create 'terraform-flux-cluster-variables' ConfigMap for flux/Kustomization postBuild use | `map(string)` | `{}` | no |
 | <a name="input_controller_ssh_known_hosts"></a> [controller\_ssh\_known\_hosts](#input\_controller\_ssh\_known\_hosts) | SSH known hosts for flux controller. Defaults to github.com ECDSA key. | `string` | `"github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="` | no |
+| <a name="input_delete_git_manifests"></a> [delete\_git\_manifests](#input\_delete\_git\_manifests) | Delete manifests from git repository. Defaults to true. | `bool` | `true` | no |
+| <a name="input_flux_system_prune"></a> [flux\_system\_prune](#input\_flux\_system\_prune) | Whether pruning should be set on flux-system Kustomization. Defaults to true | `bool` | `true` | no |
 | <a name="input_fluxcd_version"></a> [fluxcd\_version](#input\_fluxcd\_version) | Flux version to use | `string` | `"v2.3.0"` | no |
+| <a name="input_keep_namespace"></a> [keep\_namespace](#input\_keep\_namespace) | Keep the namespace after uninstalling Flux components. Defaults to true | `bool` | `true` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy fluxcd to | `string` | `"flux-system"` | no |
 | <a name="input_pod_labels"></a> [pod\_labels](#input\_pod\_labels) | Labels to add to the kustomize-controller pods | `map(string)` | `{}` | no |
 | <a name="input_service_account_annotations"></a> [service\_account\_annotations](#input\_service\_account\_annotations) | Annotations to add to the kustomize-controller service account | `map(string)` | `{}` | no |

--- a/kustomization.yaml.tpl
+++ b/kustomization.yaml.tpl
@@ -33,6 +33,7 @@ patches:
     metadata:
       name: flux-system
     spec:
+      prune: ${flux_system_prune}
       decryption:
         provider: sops
   target:

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,13 @@ resource "flux_bootstrap_git" "this" {
   version    = var.fluxcd_version
   depends_on = [kubernetes_secret.flux_system_secret]
 
+  timeouts = {
+    create = "2m"
+    delete = "2m"
+    read   = "2m"
+    update = "2m"
+  }
+
   lifecycle {
     replace_triggered_by = [terraform_data.fluxcd_reprovision]
   }

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,8 @@ resource "flux_bootstrap_git" "this" {
   ## and create the secret beforehand
   disable_secret_creation = true
   path                    = var.path
+  delete_git_manifests    = var.delete_git_manifests
+  keep_namespace          = var.keep_namespace
   watch_all_namespaces    = var.watch_all_namespaces
   kustomization_override = templatefile("${path.module}/kustomization.yaml.tpl", {
     service_account_annotations = jsonencode(var.service_account_annotations)

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ resource "flux_bootstrap_git" "this" {
     service_account_annotations = jsonencode(var.service_account_annotations)
     service_account_labels      = jsonencode(var.service_account_labels)
     pod_labels                  = jsonencode(var.pod_labels)
+    flux_system_prune           = jsonencode(var.flux_system_prune)
   })
   version    = var.fluxcd_version
   depends_on = [kubernetes_secret.flux_system_secret]

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,10 @@ resource "kubernetes_secret" "flux_cluster_secrets" {
 ################################################################################
 # FluxCD bootstrapping
 ################################################################################
+resource "terraform_data" "fluxcd_reprovision" {
+  input = var.path
+}
+
 resource "flux_bootstrap_git" "this" {
   ## Using read-only secret for flux controller, so need to disable the creation
   ## and create the secret beforehand
@@ -67,4 +71,8 @@ resource "flux_bootstrap_git" "this" {
   })
   version    = var.fluxcd_version
   depends_on = [kubernetes_secret.flux_system_secret]
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.fluxcd_reprovision]
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,9 @@ variable "keep_namespace" {
   type        = bool
   default     = true
 }
+
+variable "flux_system_prune" {
+  description = "Whether pruning should be set on flux-system Kustomization. Defaults to true"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,17 @@ variable "fluxcd_version" {
   type        = string
   default     = "v2.3.0"
 }
+
+variable "delete_git_manifests" {
+  description = "Delete manifests from git repository. Defaults to true."
+  type        = bool
+  default     = true
+}
+
+// FluxCD defaults to false, but the module explicitly creates the namespace,
+// so flux_bootstrap_git should not be removing it.
+variable "keep_namespace" {
+  description = "Keep the namespace after uninstalling Flux components. Defaults to true"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
There are two new variables, which might need configuration:

* `delete_git_manifests` - whether to delete git manifests on uninstall
  * defaulting to provider default

* `keep_namespace` - whether to keep namespace (and its' resources on uninstall)
  * the provider defaults to NOT keeping the namespace, but since this module creates the namespace explicitly due to secrets, removing `flux_bootstrap_git` resource probably shouldn't try to remove it. It's still configurable when needed though.


Additionally: allow setting `prune` for `flux-system` Kustomization. When FluxCD needs reconfiguration (like path), it might be desired to avoid touching existing resources.


Ref: https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git#delete_git_manifests