### PR TITLE
Add Dependabot to update Terraform and Github Actions deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: .github/workflows
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Currently configured to run weekly, matching other repos we maintain.
Without this the Flux provider will not be updated which in turns means
Flux itself in k8s will not be updated either.