### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @neondatabase/sre


### PR DESCRIPTION
We currently don't have one defined, meaning PRs are left without a
default reviewer.